### PR TITLE
fix: [icon] the dde-dock show icon of deepin-shortcut-viewer

### DIFF
--- a/view/mainwidget.cpp
+++ b/view/mainwidget.cpp
@@ -37,9 +37,13 @@ void MainWidget::setJsonData(const QString &data)
 
 void MainWidget::initUI()
 {
-    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog);
-    if (qApp->platformName() == "wayland")
+    if (qApp->platformName() == "wayland") {
+        setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog);
         setWindowFlag(Qt::FramelessWindowHint);
+    } else {
+        setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Popup);
+    }
+
 
     m_mainLayout = new QVBoxLayout;
     m_mainLayout->setMargin(0);


### PR DESCRIPTION
set the window flag of Popup, let the dde-dock not show the icon

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-242963.html