### PR TITLE
fix: 修复窗口位置显示不正确的问题

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -100,15 +100,15 @@ void SingleApplication::processArgs(const QStringList &list)
     }
 
     w->setJsonData(jsonData);
-    pos -= QPoint(w->width() / 2, w->height() / 2);
 
     if (cmdManager.enableBypassWindowManagerHint()) {
         qDebug() << "Setting bypass window manager hint";
         w->setWindowFlags(w->windowFlags() | Qt::BypassWindowManagerHint);
     }
 
-    w->show();
+    pos -= QPoint(w->width() / 2, w->height() / 2);
     w->move(pos);
+    w->show();
     w->setFocus();
 }
 


### PR DESCRIPTION
将 move() 调用移到 show() 之前，避免窗口先显示在错误位置再移动导致的闪烁，
同时确保在 setJsonData() 完成布局计算后再获取窗口尺寸。

Log: 修复窗口位置显示不正确的问题
Bug: https://pms.uniontech.com/bug-view-325485.html