### PR TITLE
fix: 修复窗口位置显示不正确的问题

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-shortcut-viewer (5.5.5) unstable; urgency=medium
+
+  * fix: 修复窗口位置显示不正确的问题
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Sun, 04 Jan 2026 14:30:00 +0800
+
 deepin-shortcut-viewer (5.5.4) unstable; urgency=medium
 
   * fix: 修复窗口位置显示不正确的问题 (#22)


### PR DESCRIPTION
将 move() 调用移到 show() 之前，避免窗口先显示在错误位置再移动导致的闪烁，
同时确保在 setJsonData() 完成布局计算后再获取窗口尺寸。

Log: 修复窗口位置显示不正确的问题
Bug: https://pms.uniontech.com/bug-view-325485.html