### PR TITLE
fix: [core] window positioning incorrect after size calculation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
     //Handle singlelentan process communications;
     if (isSingleApplication) {
-        SingleApplication::processArgs(app.arguments());
+        app.processArgs(app.arguments());
 
         return app.exec();
     } else {

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -35,7 +35,7 @@ void SingleApplication::initConnect()
 
 void SingleApplication::newClientProcess(const QString &key, const QByteArray &message)
 {
-    qDebug() << "The deepin-shortcut-viewer is running!";
+    qDebug() << "The deepin-shortcut-viewer is running!" << qApp->applicationPid();
     QLocalSocket *localSocket = new QLocalSocket;
     localSocket->connectToServer(userServerName(key));
     if (localSocket->waitForConnected(1000)) {
@@ -49,7 +49,7 @@ void SingleApplication::newClientProcess(const QString &key, const QByteArray &m
     } else {
         qDebug() << localSocket->errorString();
     }
-    qDebug() << "The deepin-shortcut-viewer is running end!";
+    qDebug() << "The deepin-shortcut-viewer is running end!" << qApp->applicationPid();
 }
 
 QString SingleApplication::userServerName(const QString &key)
@@ -82,6 +82,7 @@ void SingleApplication::processArgs(const QStringList &list)
 
     QString jsonData = cmdManager.jsonData();
     QPoint pos = cmdManager.pos();
+    qInfo() << " SingleApplication::processArgs ========= " << pos << qApp->applicationPid();
 
     static MainWidget *w = Q_NULLPTR;
 
@@ -93,18 +94,28 @@ void SingleApplication::processArgs(const QStringList &list)
         w = Q_NULLPTR;
     }
 
-    if (!w)
+    if (!w) {
         w = new MainWidget();
+        connect(w, &MainWidget::resizeOver, this, []{
+            if (!w || !w->property("needMovePos").isValid()) {
+                qWarning() << "SingleApplication:: reszie event to move pos, widget is nullptr : " << !w << ", valid pos : " << (w ? false : w->property("needMovePos").isValid());
+                return ;
+            }
+            auto movePos = w->property("needMovePos").value<QPoint>() - QPoint(w->width() / 2, w->height() / 2);
+            qInfo() << "SingleApplication:: reszie event to move pos, orgin pos = " << w->property("needMovePos").value<QPoint>()
+                    << ", offset pos = " << QPoint(w->width() / 2, w->height() / 2) << ", move pos = " << movePos;
+            w->setGeometry(movePos.x(), movePos.y(), w->width(), w->height());
+        });
+    }
 
     w->setJsonData(jsonData);
-    pos -= QPoint(w->width() / 2, w->height() / 2);
 
     if (cmdManager.enableBypassWindowManagerHint())
         w->setWindowFlags(w->windowFlags() | Qt::BypassWindowManagerHint);
 
+    w->setProperty("needMovePos", pos);
     w->show();
-    w->move(pos);
-    //w->activateWindow();
+
     w->setFocus();
 }
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -26,7 +26,7 @@ public:
     static QString userID();
     static QString UserID;
 
-    static void processArgs(const QStringList &list);
+    void processArgs(const QStringList &list);
 
 public slots:
     bool setSingleInstance(const QString &key);

--- a/view/mainwidget.cpp
+++ b/view/mainwidget.cpp
@@ -122,6 +122,7 @@ void MainWidget::showEvent(QShowEvent *e)
         if (DApplication::queryKeyboardModifiers() != (Qt::ShiftModifier | Qt::ControlModifier))
             hide();
     });
+    emit resizeOver();
 }
 
 void MainWidget::hideEvent(QHideEvent *e)
@@ -132,4 +133,12 @@ void MainWidget::hideEvent(QHideEvent *e)
 void MainWidget::paintEvent(QPaintEvent *e)
 {
     DBlurEffectWidget::paintEvent(e);
+}
+
+void MainWidget::resizeEvent(QResizeEvent *e)
+{
+    DBlurEffectWidget::resizeEvent(e);
+    // 当widget真正resize时，发送高度变化信号
+    // 因为它在实际几何变化后触发
+    emit resizeOver();
 }

--- a/view/mainwidget.h
+++ b/view/mainwidget.h
@@ -31,6 +31,10 @@ protected:
     void showEvent(QShowEvent *e) Q_DECL_OVERRIDE;
     void hideEvent(QHideEvent *e) Q_DECL_OVERRIDE;
     void paintEvent(QPaintEvent *e) override;
+    void resizeEvent(QResizeEvent *e) override;
+
+signals:
+    void resizeOver();
 
 private:
     void initUI();


### PR DESCRIPTION
transform processArgs to instance method, use resizeOver signal to move window after actual resize

Log: fix window positioning after resize

fix（修复）：[core] 窗口在尺寸计算后定位错误

将 processArgs 转换为实例方法，使用 resizeOver 信号在实际调整大小后移动窗口

Log（日志）：修复调整大小后的窗口定位问题
Bug: https://pms.uniontech.com/bug-view-353755.html