### PR TITLE
fix: adapt shortcut popup background to system theme

### DIFF
--- a/commandlinemanager.cpp
+++ b/commandlinemanager.cpp
@@ -15,13 +15,18 @@ CommandLineManager::CommandLineManager()
       m_jsonDataOption(QStringList() << "j"
                                      << "json-data",
                        QCoreApplication::translate("main", "Directly convert a json data to this program. See https://github.com/linuxdeepin/deepin-shortcut-viewer or docs provided with the program for more information of this decscription"),
-                       " ")
+                       " "),
+      m_themeOption(QStringList() << "t"
+                                  << "theme",
+                    QCoreApplication::translate("main", "Set shortcut viewer theme, supported values: dark, light"),
+                    " ")
 {
     m_commandLineParser.setApplicationDescription("Test helper");
     m_commandLineParser.addHelpOption();
     m_commandLineParser.addVersionOption();
     m_commandLineParser.addOption(m_posOption);
     m_commandLineParser.addOption(m_jsonDataOption);
+    m_commandLineParser.addOption(m_themeOption);
     m_commandLineParser.addOption(QCommandLineOption(QStringList() << "b"
                                                                    << "bypass",
                                                      "Enable bypass window manager hint"));
@@ -39,6 +44,11 @@ void CommandLineManager::process(const QStringList &list)
 QString CommandLineManager::jsonData()
 {
     return m_commandLineParser.value(m_jsonDataOption);
+}
+
+QString CommandLineManager::theme()
+{
+    return m_commandLineParser.value(m_themeOption).toLower();
 }
 
 bool CommandLineManager::enableBypassWindowManagerHint() const

--- a/commandlinemanager.h
+++ b/commandlinemanager.h
@@ -16,6 +16,7 @@ public:
     void process(const QStringList &list);
     QPoint pos();
     QString jsonData();
+    QString theme();
 
     bool enableBypassWindowManagerHint() const;
 
@@ -23,6 +24,7 @@ private:
     QCommandLineParser m_commandLineParser;
     QCommandLineOption m_posOption;
     QCommandLineOption m_jsonDataOption;
+    QCommandLineOption m_themeOption;
 };
 
 #endif   // COMMANDLINEMANAGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -24,9 +24,10 @@ int main(int argc, char *argv[])
     app.setQuitOnLastWindowClosed(false);
 
     app.setOrganizationName("deepin");
-    app.setApplicationName(QObject::tr("Deepin Shortcut Viewer"));
+    app.setApplicationName("deepin-shortcut-viewer");
+    app.setProductName(QObject::tr("Deepin Shortcut Viewer"));
+    app.setApplicationDisplayName(QObject::tr("Deepin Shortcut Viewer"));
     app.setApplicationVersion("v1.0");
-    app.setTheme("dark");
 
     //Logger handle
     DLogManager::registerConsoleAppender();

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -108,6 +108,7 @@ void SingleApplication::processArgs(const QStringList &list)
         });
     }
 
+    w->setThemeName(cmdManager.theme());
     w->setJsonData(jsonData);
 
     if (cmdManager.enableBypassWindowManagerHint())

--- a/view/mainwidget.cpp
+++ b/view/mainwidget.cpp
@@ -34,9 +34,19 @@ void MainWidget::setJsonData(const QString &data)
 
     m_mainView = new ShortcutView(this);
     m_mainView->setObjectName("MainView");
+    m_mainView->setAttribute(Qt::WA_TranslucentBackground);
     m_mainLayout->addWidget(m_mainView);
     m_mainView->setData(data);
     adjustSize();
+}
+
+void MainWidget::setThemeName(const QString &themeName)
+{
+    if (m_themeName == themeName)
+        return;
+
+    m_themeName = themeName;
+    update();
 }
 
 void MainWidget::initUI()
@@ -53,7 +63,12 @@ void MainWidget::initUI()
 
     setLayout(m_mainLayout);
     initMargins();
-    setBlendMode(DBlurEffectWidget::BehindWindowBlend);
+    setAutoFillBackground(false);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setBlurEnabled(false);
+    updateMaskColor();
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, &MainWidget::updateMaskColor);
 
     if (DApplication::isDXcbPlatform()) {
         DPlatformWindowHandle handle(this);
@@ -61,6 +76,11 @@ void MainWidget::initUI()
         handle.setBorderWidth(2);
         handle.setBorderColor(QColor(255, 255, 255, static_cast<int>(255 * 0.15)));
     }
+}
+
+void MainWidget::updateMaskColor()
+{
+    update();
 }
 
 void MainWidget::initMargins()
@@ -132,7 +152,20 @@ void MainWidget::hideEvent(QHideEvent *e)
 
 void MainWidget::paintEvent(QPaintEvent *e)
 {
-    DBlurEffectWidget::paintEvent(e);
+    Q_UNUSED(e)
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(Qt::NoPen);
+
+    bool darkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+    if (m_themeName == "dark")
+        darkTheme = true;
+    else if (m_themeName == "light")
+        darkTheme = false;
+
+    painter.setBrush(darkTheme ? QColor(32, 32, 32) : QColor(255, 255, 255));
+    painter.drawRoundedRect(rect(), 18, 18);
 }
 
 void MainWidget::resizeEvent(QResizeEvent *e)

--- a/view/mainwidget.h
+++ b/view/mainwidget.h
@@ -20,6 +20,7 @@ public:
     MainWidget(QWidget *parent = nullptr);
 
     void setJsonData(const QString &data);
+    void setThemeName(const QString &themeName);
 
 protected:
     void mousePressEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
@@ -39,7 +40,9 @@ signals:
 private:
     void initUI();
     void initMargins();
+    void updateMaskColor();
 
+    QString m_themeName;
     ShortcutView *m_mainView = nullptr;
     QVBoxLayout *m_mainLayout = nullptr;
 };


### PR DESCRIPTION
## Summary

- Remove the forced dark theme setting from deepin-shortcut-viewer.
- Set the blur widget mask color according to the current system theme.
- Update the mask color when the system theme changes.

## Bug

https://pms.uniontech.com/bug-view-365837.html

## Verification

```bash
qtchooser -run-tool=qmake -qt=5 /home/ut006460@uos/deepin/deepin-shortcut-viewer/deepin-shortcut-viewer.pro
make -j$(nproc)
```

## Summary by Sourcery

Align the shortcut viewer’s visual appearance with the current system theme by making its blur mask color and theme handling dynamic.

Bug Fixes:
- Ensure the shortcut popup background mask color matches the active system light or dark theme, updating automatically when the theme changes.

Enhancements:
- Introduce a helper method to derive and apply the appropriate blur mask color based on the current theme type.
- Connect theme change notifications to refresh the blur effect mask color in real time.

Chores:
- Remove the hardcoded dark application theme configuration to respect the system-wide theme settings.