### PR TITLE
fix: adapt shortcut popup background to system theme

### DIFF
--- a/commandlinemanager.cpp
+++ b/commandlinemanager.cpp
@@ -15,13 +15,18 @@ CommandLineManager::CommandLineManager()
       m_jsonDataOption(QStringList() << "j"
                                      << "json-data",
                        QCoreApplication::translate("main", "Directly convert a json data to this program. See https://github.com/linuxdeepin/deepin-shortcut-viewer or docs provided with the program for more information of this decscription"),
-                       " ")
+                       " "),
+      m_themeOption(QStringList() << "t"
+                                  << "theme",
+                    QCoreApplication::translate("main", "Set shortcut viewer theme, supported values: dark, light"),
+                    " ")
 {
     m_commandLineParser.setApplicationDescription("Test helper");
     m_commandLineParser.addHelpOption();
     m_commandLineParser.addVersionOption();
     m_commandLineParser.addOption(m_posOption);
     m_commandLineParser.addOption(m_jsonDataOption);
+    m_commandLineParser.addOption(m_themeOption);
     m_commandLineParser.addOption(QCommandLineOption(QStringList() << "b"
                                                                    << "bypass",
                                                      "Enable bypass window manager hint"));
@@ -39,6 +44,11 @@ void CommandLineManager::process(const QStringList &list)
 QString CommandLineManager::jsonData()
 {
     return m_commandLineParser.value(m_jsonDataOption);
+}
+
+QString CommandLineManager::theme()
+{
+    return m_commandLineParser.value(m_themeOption).toLower();
 }
 
 bool CommandLineManager::enableBypassWindowManagerHint() const

--- a/commandlinemanager.h
+++ b/commandlinemanager.h
@@ -16,6 +16,7 @@ public:
     void process(const QStringList &list);
     QPoint pos();
     QString jsonData();
+    QString theme();
 
     bool enableBypassWindowManagerHint() const;
 
@@ -23,6 +24,7 @@ private:
     QCommandLineParser m_commandLineParser;
     QCommandLineOption m_posOption;
     QCommandLineOption m_jsonDataOption;
+    QCommandLineOption m_themeOption;
 };
 
 #endif   // COMMANDLINEMANAGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -24,9 +24,10 @@ int main(int argc, char *argv[])
     app.setQuitOnLastWindowClosed(false);
 
     app.setOrganizationName("deepin");
-    app.setApplicationName(QObject::tr("Deepin Shortcut Viewer"));
+    app.setApplicationName("deepin-shortcut-viewer");
+    app.setProductName(QObject::tr("Deepin Shortcut Viewer"));
+    app.setApplicationDisplayName(QObject::tr("Deepin Shortcut Viewer"));
     app.setApplicationVersion("v1.0");
-    app.setTheme("dark");
 
     //Logger handle
     DLogManager::registerConsoleAppender();

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -9,6 +9,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QProcess>
+#include <QPointer>
 #include <QDir>
 
 QString SingleApplication::UserID = "1000";
@@ -96,18 +97,21 @@ void SingleApplication::processArgs(const QStringList &list)
 
     if (!w) {
         w = new MainWidget();
-        connect(w, &MainWidget::resizeOver, this, []{
-            if (!w || !w->property("needMovePos").isValid()) {
-                qWarning() << "SingleApplication:: reszie event to move pos, widget is nullptr : " << !w << ", valid pos : " << (w ? false : w->property("needMovePos").isValid());
+        QPointer<MainWidget> weakWidget = w;
+        connect(w, &MainWidget::resizeOver, this, [weakWidget]{
+            if (weakWidget.isNull() || !weakWidget->property("needMovePos").isValid()) {
+                qWarning() << "SingleApplication:: reszie event to move pos, widget is nullptr : " << weakWidget.isNull()
+                           << ", valid pos : " << (!weakWidget.isNull() && weakWidget->property("needMovePos").isValid());
                 return ;
             }
-            auto movePos = w->property("needMovePos").value<QPoint>() - QPoint(w->width() / 2, w->height() / 2);
-            qInfo() << "SingleApplication:: reszie event to move pos, orgin pos = " << w->property("needMovePos").value<QPoint>()
-                    << ", offset pos = " << QPoint(w->width() / 2, w->height() / 2) << ", move pos = " << movePos;
-            w->setGeometry(movePos.x(), movePos.y(), w->width(), w->height());
+            auto movePos = weakWidget->property("needMovePos").value<QPoint>() - QPoint(weakWidget->width() / 2, weakWidget->height() / 2);
+            qInfo() << "SingleApplication:: reszie event to move pos, orgin pos = " << weakWidget->property("needMovePos").value<QPoint>()
+                    << ", offset pos = " << QPoint(weakWidget->width() / 2, weakWidget->height() / 2) << ", move pos = " << movePos;
+            weakWidget->setGeometry(movePos.x(), movePos.y(), weakWidget->width(), weakWidget->height());
         });
     }
 
+    w->setThemeName(cmdManager.theme());
     w->setJsonData(jsonData);
 
     if (cmdManager.enableBypassWindowManagerHint())

--- a/view/mainwidget.cpp
+++ b/view/mainwidget.cpp
@@ -15,12 +15,14 @@
 #include <QPainter>
 #include <QPalette>
 #include <QKeyEvent>
+#include <QPainterPath>
+#include <QRegion>
 #include <QScreen>
 
 DWIDGET_USE_NAMESPACE
 
 MainWidget::MainWidget(QWidget *parent)
-    : DBlurEffectWidget(parent)
+    : DWidget(parent)
 {
     initUI();
 }
@@ -34,9 +36,19 @@ void MainWidget::setJsonData(const QString &data)
 
     m_mainView = new ShortcutView(this);
     m_mainView->setObjectName("MainView");
+    m_mainView->setAttribute(Qt::WA_TranslucentBackground);
     m_mainLayout->addWidget(m_mainView);
     m_mainView->setData(data);
     adjustSize();
+}
+
+void MainWidget::setThemeName(const QString &themeName)
+{
+    if (m_themeName == themeName)
+        return;
+
+    m_themeName = themeName;
+    update();
 }
 
 void MainWidget::initUI()
@@ -53,7 +65,10 @@ void MainWidget::initUI()
 
     setLayout(m_mainLayout);
     initMargins();
-    setBlendMode(DBlurEffectWidget::BehindWindowBlend);
+    setAutoFillBackground(false);
+    setAttribute(Qt::WA_TranslucentBackground);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, QOverload<>::of(&MainWidget::update));
 
     if (DApplication::isDXcbPlatform()) {
         DPlatformWindowHandle handle(this);
@@ -87,14 +102,14 @@ void MainWidget::initMargins()
 void MainWidget::mousePressEvent(QMouseEvent *e)
 {
     hide();
-    DBlurEffectWidget::mousePressEvent(e);
+    DWidget::mousePressEvent(e);
 }
 
 void MainWidget::keyReleaseEvent(QKeyEvent *e)
 {
     if (e->key() == Qt::Key_Control || e->key() == Qt::Key_Shift) {
         releaseKeyboard();
-        DBlurEffectWidget::keyReleaseEvent(e);
+        DWidget::keyReleaseEvent(e);
         hide();
     }
 }
@@ -102,7 +117,7 @@ void MainWidget::keyReleaseEvent(QKeyEvent *e)
 void MainWidget::focusInEvent(QFocusEvent *e)
 {
     grabKeyboard();
-    DBlurEffectWidget::focusInEvent(e);
+    DWidget::focusInEvent(e);
 }
 
 void MainWidget::keyPressEvent(QKeyEvent *e)
@@ -113,7 +128,7 @@ void MainWidget::keyPressEvent(QKeyEvent *e)
 
 void MainWidget::showEvent(QShowEvent *e)
 {
-    DBlurEffectWidget::showEvent(e);
+    DWidget::showEvent(e);
 
     setFocus(Qt::MouseFocusReason);
     grabKeyboard();
@@ -127,17 +142,39 @@ void MainWidget::showEvent(QShowEvent *e)
 
 void MainWidget::hideEvent(QHideEvent *e)
 {
-    DBlurEffectWidget::hideEvent(e);
+    DWidget::hideEvent(e);
 }
 
 void MainWidget::paintEvent(QPaintEvent *e)
 {
-    DBlurEffectWidget::paintEvent(e);
+    Q_UNUSED(e)
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(Qt::NoPen);
+
+    const auto themeType = DGuiApplicationHelper::instance()->themeType();
+    const QColor backgroundColor = DGuiApplicationHelper::instance()->applicationPalette().color(QPalette::Background);
+    bool darkTheme = themeType == DGuiApplicationHelper::DarkType || backgroundColor.lightness() < 128;
+    if (m_themeName == "dark")
+        darkTheme = true;
+    else if (m_themeName == "light")
+        darkTheme = false;
+
+    QPainterPath path;
+    path.addRoundedRect(rect(), 18, 18);
+    painter.setBrush(darkTheme ? QColor(32, 32, 32) : QColor(255, 255, 255));
+    painter.drawPath(path);
 }
 
 void MainWidget::resizeEvent(QResizeEvent *e)
 {
-    DBlurEffectWidget::resizeEvent(e);
+    DWidget::resizeEvent(e);
+
+    QPainterPath path;
+    path.addRoundedRect(rect(), 18, 18);
+    setMask(QRegion(path.toFillPolygon().toPolygon()));
+
     // 当widget真正resize时，发送高度变化信号
     // 因为它在实际几何变化后触发
     emit resizeOver();

--- a/view/mainwidget.h
+++ b/view/mainwidget.h
@@ -5,7 +5,7 @@
 #ifndef MAINWIDGET_H
 #define MAINWIDGET_H
 
-#include <DBlurEffectWidget>
+#include <DWidget>
 #include <QVBoxLayout>
 
 #define CONTENT_MARGINS 30
@@ -13,13 +13,14 @@
 DWIDGET_USE_NAMESPACE
 
 class ShortcutView;
-class MainWidget : public DBlurEffectWidget
+class MainWidget : public DWidget
 {
     Q_OBJECT
 public:
     MainWidget(QWidget *parent = nullptr);
 
     void setJsonData(const QString &data);
+    void setThemeName(const QString &themeName);
 
 protected:
     void mousePressEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
@@ -40,6 +41,7 @@ private:
     void initUI();
     void initMargins();
 
+    QString m_themeName;
     ShortcutView *m_mainView = nullptr;
     QVBoxLayout *m_mainLayout = nullptr;
 };


### PR DESCRIPTION
## Summary
- Add --theme support for shortcut popup rendering
- Paint the popup background with solid light/dark colors
- Use stable application id for DTK configuration

## Test
- Built and installed deepin-shortcut-viewer locally
- Verified the shortcut popup can render black background when launched with dark theme

PMS: BUG-365837