### PR TITLE
fix: sync shortcut viewer theme with caller-provided --theme (PMS #373655)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 #include <DLog>
 //#include "widget.h"
 #include "./view/mainwidget.h"
+#include <DGuiApplicationHelper>
 #include <QRect>
 #include <QPoint>
 #include <QFile>
@@ -28,6 +29,15 @@ int main(int argc, char *argv[])
     app.setProductName(QObject::tr("Deepin Shortcut Viewer"));
     app.setApplicationDisplayName(QObject::tr("Deepin Shortcut Viewer"));
     app.setApplicationVersion("v1.0");
+
+    // The viewer is a transient popup: its theme must follow the system theme
+    // or the --theme passed by the caller, but must never persist that
+    // transient choice to the user's DTK theme preference (org.deepin.dtk.
+    // preference). Without this, a caller passing --theme=light would write
+    // "light" to the dconfig and the viewer would later start in light theme
+    // regardless of the actual system theme. This also keeps the
+    // setPaletteType() call in MainWidget::setThemeName non-persistent.
+    DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::DontSaveApplicationTheme, true);
 
     //Logger handle
     DLogManager::registerConsoleAppender();

--- a/view/mainwidget.cpp
+++ b/view/mainwidget.cpp
@@ -48,6 +48,23 @@ void MainWidget::setThemeName(const QString &themeName)
         return;
 
     m_themeName = themeName;
+
+    // Sync the application palette type with the requested theme so that child
+    // widgets deriving their colors from DGuiApplicationHelper::themeType()
+    // (e.g. ShortcutItem text) stay consistent with the popup background,
+    // which already honors --theme. Without this the foreground follows the
+    // system theme while the background follows --theme, producing a
+    // low-contrast popup when the two differ (e.g. system dark + app light).
+    //
+    // setPaletteType is used instead of the deprecated setThemeType (which
+    // merely forwards to setPaletteType). DontSaveApplicationTheme is set in
+    // main() so this never persists the caller's transient theme to the user's
+    // DTK theme preference.
+    if (themeName == "dark")
+        DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::DarkType);
+    else if (themeName == "light")
+        DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::LightType);
+
     update();
 }
 

--- a/view/shortcutitem.cpp
+++ b/view/shortcutitem.cpp
@@ -18,21 +18,21 @@ ShortcutItem::ShortcutItem(bool isGroup, QWidget *parent)
     : QWidget(parent),
       m_isGroup(isGroup)
 {
-    QColor textColor = QColor(65, 77, 104);
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        textColor = QColor(192, 198, 212);
-    QPalette labelPalette;
-    labelPalette.setColor(QPalette::WindowText, textColor);
-
     m_nameLabel = new QLabel(this);
     m_nameLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     m_nameLabel->setWordWrap(true);
-    m_nameLabel->setPalette(labelPalette);
 
     m_valueLabel = new QLabel(this);
     m_valueLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_valueLabel->setWordWrap(true);
-    m_valueLabel->setPalette(labelPalette);
+
+    // The text color derives from the application theme type, which
+    // MainWidget::setThemeName syncs to the --theme passed by the caller.
+    // Re-apply the palette on theme changes so existing items stay consistent
+    // with the popup background instead of only honoring the system theme.
+    updateLabelPalette();
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, &ShortcutItem::updateLabelPalette);
 
     QHBoxLayout *mainLayout = new QHBoxLayout(this);
     mainLayout->addWidget(m_nameLabel);
@@ -82,6 +82,19 @@ ShortcutItem::ShortcutItem(bool isGroup, QWidget *parent)
 
     setLayout(mainLayout);
     setFixedWidth(width);
+}
+
+void ShortcutItem::updateLabelPalette()
+{
+    QColor textColor = QColor(65, 77, 104);
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
+        textColor = QColor(192, 198, 212);
+
+    QPalette labelPalette;
+    labelPalette.setColor(QPalette::WindowText, textColor);
+
+    m_nameLabel->setPalette(labelPalette);
+    m_valueLabel->setPalette(labelPalette);
 }
 
 void ShortcutItem::setText(const QString &name, const QString &value)

--- a/view/shortcutitem.h
+++ b/view/shortcutitem.h
@@ -25,6 +25,8 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
+    void updateLabelPalette();
+
     bool m_hasBackground = false;
     bool m_isGroup = false;
 


### PR DESCRIPTION
# PMS #373655: shortcut popup blurry when system dark + app light

关联 PMS：https://pms.uniontech.com/bug-view-373655.html
目标分支：`develop/eagle`（基线 `fac0172`）

## 现象

系统主题为深色、应用（语音记事本）主题为浅色时，按 `Shift+Ctrl+?` 切出的快捷键弹窗"模糊不清"，必现。

## 根因分析

同一弹窗的前景与背景取自**不同主题来源**：

- **背景色**受 `--theme` 控制 —— `view/mainwidget.cpp` `paintEvent` 中 `m_themeName=="light"` → 画 `QColor(255,255,255)`（白底）。
- **前景文字色**不受 `--theme`，只读系统 `themeType()` —— `view/shortcutitem.cpp:22` 构造时一次性写入 label palette：`themeType()==DarkType` → 文字 `QColor(192,198,212)`（浅灰）。
- **`--theme` 入口不传播主题** —— `view/mainwidget.cpp` `setThemeName` 仅 `m_themeName=...; update()`，从不调用 `setPaletteType`/`setThemeType`，故 `themeType()` 永不随 `--theme` 变化。

触发（系统深色 + 应用浅色）：voice-note 传 `--theme=light` → 背景白；viewer 独立进程随系统深色 → `themeType()=DarkType` → 前景浅灰字；浅灰文字叠白底，对比度≈1.72:1（远低于 WCAG AA 4.5:1）→ "模糊不清"。该机理只在 `--theme` ≠ 系统主题时触发，与 PMS 场景精确吻合。

voice-note 侧的 `--theme` 传递（`f9f479fd`，"传递语音记事本当前有效主题"）符合设计，非根因，本 PR 不涉及。

## 修复方案（方向 A + 安全增强）

1. **`MainWidget::setThemeName`**：据 `themeName` 调 `DGuiApplicationHelper::setPaletteType(DarkType/LightType)`，使 `themeType()` 随 `--theme` 变化，前景（读 `themeType()`）与背景（按 `--theme`）统一。使用非废弃的 `setPaletteType` 替代已废弃的 `setThemeType`（`setThemeType` 仅转发到 `setPaletteType`，DTK 头标注 `D_DECL_DEPRECATED_X("Plase use setPaletteType")`）。
2. **`ShortcutItem`**：将构造内一次性设定的文字调色板逻辑提取为 `updateLabelPalette()`，构造时调用并 `connect(themeTypeChanged, updateLabelPalette)`，使**已存在**的 item 在主题变化时刷新前景色（仅 `setPaletteType` 不会自动刷新已构造 item 的 palette，否则只有新生成弹窗生效）。
3. **`main.cpp`**：设置 `DGuiApplicationHelper::DontSaveApplicationTheme`。这是**必需的安全增强**：`setPaletteType` 默认会把主题写入 dconfig（`org.deepin.dtk.preference`），若不加该属性，调用方传入的临时 `--theme` 会被持久化，导致查看器下次启动时使用上次的 `--theme` 而非跟随系统主题——这违背 `fac0172`"弹窗背景跟随系统主题"的设计意图，且会引入新缺陷。设置该属性后：启动时 `paletteType=UnknownType`（跟随系统），`--theme` 仅在进程内生效、不持久化。

背景侧 `paintEvent` 已连 `themeTypeChanged`→`update()`（`mainwidget.cpp:70-71`），无需改动。

## 改动安全评估

- **风险等级：低**。无签名变更；`setThemeName` 唯一调用者 `singleapplication.cpp:114` 不受影响。
- `setThemeName` 由基线 `fac0172` 新引入，非历史修复产物，无回归风险。
- `ShortcutItem` 调色板逻辑自 2022 年稳定，无近期冲突。
- 在 Qt 5.15.8 + 本机 dtkgui 6.7.47 上对 3 个改动文件做 `g++ -fsyntax-only` 检查：**0 error、0 deprecation warning**。
- `DontSaveApplicationTheme` 是 DTK 标准属性，阻止 dconfig 读写，不影响 `setPaletteType` 在进程内的主题生效与 `themeTypeChanged` 信号发射。

## 验证建议

项目无 UT 目录。建议在「系统深色 + 应用浅色」环境下实跑：`Shift+Ctrl+?` 弹窗应白底深字（可读）；对称场景「系统浅色 + 应用深色」应深底浅字（可读）；不传 `--theme` 时应跟随系统主题。

## 改动文件

- `main.cpp` — 设置 `DontSaveApplicationTheme`
- `view/mainwidget.cpp` — `setThemeName` 同步 `setPaletteType`
- `view/shortcutitem.cpp` — 提取 `updateLabelPalette` + 监听 `themeTypeChanged`
- `view/shortcutitem.h` — 声明 `updateLabelPalette`

## Summary by Sourcery

Synchronize shortcut viewer colors with caller-provided themes without persisting transient theme settings.

Bug Fixes:
- Ensure shortcut viewer text and background remain readable when the caller-provided theme differs from the system theme.

Enhancements:
- Synchronize the viewer palette with --theme and refresh existing shortcut items when the theme changes.
- Prevent transient viewer theme selections from being persisted to the user's application theme settings.